### PR TITLE
Fix #27 by adding `#merge`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
         gem install rubocop
         gem install rubocop-rspec
     - name: Run Lints
-      run: rubocop
+      run: rubocop lib spec example
     - uses: actions/cache@v2
       with:
         path: example/vendor/bundle

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,8 @@ jobs:
       run: |
         bundle config path vendor/bundle
         bundle install
+        gem install rubocop
+        gem install rubocop-rspec
     - name: Run Lints
       run: rubocop
     - uses: actions/cache@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,15 +1,50 @@
-name: Linters
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
-on: [push]
+name: Ruby Lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
-  build:
+  test:
+
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ '2.6', '2.7' ]
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Rubocop Linter
-      uses: andrewmcodes/rubocop-linter-action@v3.0.0
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
       with:
-        action_config_path: '.github/config/rubocop_linter_action.yml' # Note: this is the default location
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ruby-version:  ${{ matrix.ruby }}
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-${{ matrix.ruby }}-gem-deps-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ruby }}-gem-deps-
+    - name: Install dependencies
+      run: |
+        bundle config path vendor/bundle
+        bundle install
+    - name: Run Lints
+      run: rubocop
+    - uses: actions/cache@v2
+      with:
+        path: example/vendor/bundle
+        key: ${{ runner.os }}-${{ matrix.ruby }}-example-deps-${{ hashFiles('example/**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ruby }}-example-deps-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,8 @@ RSpec/ImplicitBlockExpectation:
   Enabled: false
 RSpec/ImplicitExpect:
   EnforcedStyle: should
+RSpec/LeadingSubject:
+  Enabled: false
 Style/MultilineBlockChain:
   Enabled: false
 Metrics/AbcSize:

--- a/docs/serializers.md
+++ b/docs/serializers.md
@@ -201,3 +201,29 @@ end
 ```
 
 For clarity (and to prevent infinitely-looping serializers on accident, we recommend you *always* use an explicit view for dependent output objects.
+
+### "Inheritance"
+
+Output objects don't support inheritance.
+You can't have one output object based on another.
+You *can*, however, merge one into another!
+Consdier this case:
+
+```ruby
+GenericBioOutput = SoberSwag::OutputObject.define do
+  field :name, primitive(:String)
+  field :brief_history, primtiive(:String)
+end
+
+ExecutiveBioOutput = SoberSwag::OutputObject.define do
+  merge GenericBioOutput
+  field :company, primitive(:String)
+  field :position, primitive(:String)
+end
+```
+
+Using `#merge` lets you add in all the fields from one output object into another.
+You can even use `merge` from within a view.
+
+Note that `merge` does *not* copy anything but fields.
+Identifiers and views will not be copied over.

--- a/lib/sober_swag/output_object/field_syntax.rb
+++ b/lib/sober_swag/output_object/field_syntax.rb
@@ -12,6 +12,15 @@ module SoberSwag
       def primitive(name)
         SoberSwag::Serializer.primitive(SoberSwag::Types.const_get(name))
       end
+
+      ##
+      # Merge in anything that has a list of fields, and use it.
+      # Note that merging in a full blueprint *will not* also merge in views, just fields defined on the base.
+      def merge(other)
+        other.fields.each do |field|
+          add_field!(field)
+        end
+      end
     end
   end
 end

--- a/spec/sober_swag/output_object/merge_spec.rb
+++ b/spec/sober_swag/output_object/merge_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe 'merging SoberSwag output objects' do
+  let(:base) do
+    SoberSwag::OutputObject.define do
+      identifier 'MyObject'
+      field :id, primitive(:Integer)
+      field :name, primitive(:String)
+    end
+  end
+
+  context 'when merged into a blueprint' do
+    subject { example.serialize({ id: 10, name: 'Bob', items: 10 }) }
+
+    let(:example) do
+      bp = base
+      SoberSwag::OutputObject.define do
+        merge bp
+
+        field :items, primitive(:Integer)
+      end
+    end
+
+    specify { expect { subject }.not_to raise_error }
+    it { should have_key(:id) }
+    it { should have_key(:name) }
+    it { should have_key(:items) }
+  end
+
+  context 'when merged into a view' do
+    let(:target) { { id: 10, name: 'Bob', items: 10 } }
+    let(:example) do
+      bp = base
+      SoberSwag::OutputObject.define do
+        field :items, primitive(:Integer)
+
+        view :detail do
+          merge bp
+        end
+      end
+    end
+
+    context 'when used with the view' do
+      subject { example.serialize(target, view: :detail) }
+
+      specify { expect { subject }.not_to raise_error }
+
+      it { should have_key(:name) }
+      it { should have_key(:items) }
+      it { should have_key(:id) }
+    end
+
+    context 'when used without the view' do
+      subject { example.serialize(target) }
+
+      specify { expect { subject }.not_to raise_error }
+
+      it { should have_key(:items) }
+      it { should_not have_key(:name) }
+      it { should_not have_key(:id) }
+    end
+  end
+end


### PR DESCRIPTION
This adds a new item to blueprint definitions, `#merge`, which merges in
a single level of output object. This hopefully works out pretty well.

I could see the use for a `deep_merge` that also inherits views, maybe?
I dunno.

Note: the way this is currently designed *will not* work with mutual
recursion as well, which might be problematic?