### PR TITLE
Add #nilable (fix #26)

### DIFF
--- a/lib/sober_swag/serializer/base.rb
+++ b/lib/sober_swag/serializer/base.rb
@@ -18,6 +18,12 @@ module SoberSwag
       end
 
       ##
+      # Alias for optional
+      def nilable
+        optional
+      end
+
+      ##
       # Is this type lazily defined?
       #
       # Used for mutual recursion.

--- a/lib/sober_swag/serializer/base.rb
+++ b/lib/sober_swag/serializer/base.rb
@@ -17,7 +17,7 @@ module SoberSwag
         SoberSwag::Serializer::Optional.new(self)
       end
 
-      alias_method :nilable, :optional
+      alias nilable optional
 
       ##
       # Is this type lazily defined?

--- a/lib/sober_swag/serializer/base.rb
+++ b/lib/sober_swag/serializer/base.rb
@@ -17,11 +17,7 @@ module SoberSwag
         SoberSwag::Serializer::Optional.new(self)
       end
 
-      ##
-      # Alias for optional
-      def nilable
-        optional
-      end
+      alias_method :nilable, :optional
 
       ##
       # Is this type lazily defined?


### PR DESCRIPTION
This adds `nilable` as an alias of `optional` to output objects.