### PR TITLE
Add #multi api (Fix #35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## Unreleased
 
-
+- Add `multi` to Output Objects, as a way to define more than one field of the same type at once.

--- a/docs/serializers.md
+++ b/docs/serializers.md
@@ -135,6 +135,22 @@ We can see a few things here:
 2. You must provide types with field names
 3. You can use blocks to do data formatting, which lets you pick different fields and such.
 
+
+### Multi
+
+If you have a few fields of the same type, you can use `#multi` to define them all at once:
+
+```ruby
+StudentOutputObject = SoberSwag::OutputObject.define do
+  multi [:first_name, :last_name], primitive(:String)
+  field :recent_grades, primitive(:Integer).array do |student|
+    student.graded_assignments.limit(100).pluck(:grade)
+  end
+end
+```
+
+This saves a bit of typing, and can help with refactoring later.
+
 ### Views
 
 Sometimes, you might want to add "variant" ways to look at data.

--- a/lib/sober_swag/output_object/field_syntax.rb
+++ b/lib/sober_swag/output_object/field_syntax.rb
@@ -9,6 +9,7 @@ module SoberSwag
 
       ##
       # Similar to #field, but adds multiple at once.
+      # Named #multi because #fields was already taken.
       def multi(names, serializer)
         names.each { |name| field(name, serializer) }
       end

--- a/lib/sober_swag/output_object/field_syntax.rb
+++ b/lib/sober_swag/output_object/field_syntax.rb
@@ -8,6 +8,12 @@ module SoberSwag
       end
 
       ##
+      # Similar to #field, but adds multiple at once.
+      def multi(names, serializer)
+        names.each { |name| field(name, serializer) }
+      end
+
+      ##
       # Given a symbol to this, we will use a primitive name
       def primitive(name)
         SoberSwag::Serializer.primitive(SoberSwag::Types.const_get(name))

--- a/spec/sober_swag/output_object/multi_spec.rb
+++ b/spec/sober_swag/output_object/multi_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe 'using #multi on an output object' do
+  context 'when used direclty on the object' do
+    let(:output) do
+      SoberSwag::OutputObject.define do
+        identifier 'MyObject'
+        multi %i[first_name last_name], primitive(:String)
+      end
+    end
+
+    it 'serializes properly' do
+      expect(output.serialize({ first_name: 'foo', last_name: 'bar' })).to eq({ first_name: 'foo', last_name: 'bar' })
+    end
+
+    specify { expect { output }.not_to raise_error }
+  end
+
+  context 'when used on a view' do
+    let(:output) do
+      SoberSwag::OutputObject.define do
+        identifier 'Test'
+        field :rank, primitive(:Integer)
+        view(:detail) { multi %i[first_name last_name], primitive(:String) }
+      end
+    end
+
+    it 'serializes' do
+      res = { rank: 1, first_name: 'rich', last_name: 'evans' }
+      expect(output.serialize(res, view: :detail)).to eq(res)
+    end
+
+    specify { expect { output }.not_to raise_error }
+  end
+end


### PR DESCRIPTION
I would have preferred the name #fields but that was already used for
metadata, unfortunately.