### PR TITLE
Allow alternate formats

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,3 +81,5 @@ Style/RedundantRegexpEscape:
   Enabled: true
 Style/SlicingWithRange:
   Enabled: true
+RSpec/NestedGroups:
+  Max: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,8 @@
 
 - Add `multi` to Output Objects, as a way to define more than one field of the same type at once.
 - Add an `inherits:` key to output objects, for view inheritance.
+- Add `SoberSwag::Types::CommaArray`, which parses comma-separated strings into arrays.
+  This also sets `style` to `form` and `explode` to `false` when generating Swagger docs.
+  This class is mostly useful for query parameters where you want a simpler format: `tag=foo,bar` instead of `tag[]=foo,tag[]=bar`.
+- Add support for using `meta` to specify alternative `style` and `explode` keys for query and path params.
+  Note that this support *does not* extend to parsing: If you modify the `style` or `explode` keywords, you will need to make those input formats work with the actual type yourself.

--- a/bin/console
+++ b/bin/console
@@ -31,4 +31,6 @@ SchoolClass = SoberSwag.input_object do
   attribute :location, (SingleFloorLocation | MultiFloorLocation).meta(description: 'What building and room this is in')
 end
 
+SortDirections = SoberSwag::Types::CommaArray.of(SoberSwag::Types::String.enum('created_at', 'updated_at', '-created_at', '-updated_at'))
+
 Pry.start

--- a/lib/sober_swag/nodes/attribute.rb
+++ b/lib/sober_swag/nodes/attribute.rb
@@ -3,28 +3,29 @@ module SoberSwag
     ##
     # One attribute of an object.
     class Attribute < Base
-      def initialize(key, required, value)
+      def initialize(key, required, value, meta = {})
         @key = key
         @required = required
         @value = value
+        @meta = meta
       end
 
       def deconstruct
-        [key, required, value]
+        [key, required, value, meta]
       end
 
       def deconstruct_keys
-        { key: key, required: required, value: value }
+        { key: key, required: required, value: value, meta: meta }
       end
 
-      attr_reader :key, :required, :value
+      attr_reader :key, :required, :value, :meta
 
       def map(&block)
-        self.class.new(key, required, value.map(&block))
+        self.class.new(key, required, value.map(&block), meta)
       end
 
       def cata(&block)
-        block.call(self.class.new(key, required, value.cata(&block)))
+        block.call(self.class.new(key, required, value.cata(&block), meta))
       end
     end
   end

--- a/lib/sober_swag/types.rb
+++ b/lib/sober_swag/types.rb
@@ -5,14 +5,6 @@ module SoberSwag
   class Types
     include ::Dry::Types()
 
-    ##
-    # An array that will be parsed from comma-separated values in a string, if given a string.
-    CommaArray = Array.meta(format: :form, explode: false).constructor do |val|
-      if val.is_a?(::String)
-        val.split(',').map(&:strip)
-      else
-        val
-      end
-    end
+    autoload(:CommaArray, 'sober_swag/types/comma_array')
   end
 end

--- a/lib/sober_swag/types.rb
+++ b/lib/sober_swag/types.rb
@@ -4,5 +4,15 @@ module SoberSwag
   # You can use constants like SoberSwag::Types::Integer and things as a result of this module existing.
   class Types
     include ::Dry::Types()
+
+    ##
+    # An array that will be parsed from comma-separated values in a string, if given a string.
+    CommaArray = Array.meta(format: :form, explode: false).constructor do |val|
+      if val.is_a?(::String)
+        val.split(',').map(&:strip)
+      else
+        val
+      end
+    end
   end
 end

--- a/lib/sober_swag/types/comma_array.rb
+++ b/lib/sober_swag/types/comma_array.rb
@@ -1,0 +1,17 @@
+module SoberSwag
+  class Types
+    ##
+    # An array that will be parsed from comma-separated values in a string, if given a string.
+    module CommaArray
+      def self.of(other)
+        SoberSwag::Types::Array.of(other).constructor { |val|
+          if val.is_a?(::String)
+            val.split(',').map(&:strip)
+          else
+            val
+          end
+        }.meta(style: :form, explode: false)
+      end
+    end
+  end
+end

--- a/spec/sober_swag/compiler/type_spec.rb
+++ b/spec/sober_swag/compiler/type_spec.rb
@@ -245,6 +245,31 @@ RSpec.describe SoberSwag::Compiler::Type do
     end
   end
 
+  context 'with a type containing SoberSwag::Types::CommaArray' do
+    subject(:compiler) { described_class.new(type) }
+
+    let(:type) do
+      SoberSwag.input_object do
+        identifier 'test'
+        attribute :sort, SoberSwag::Types::CommaArray.of(SoberSwag::Types::String.enum('created_at', '-created_at', 'updated_at', '-updated_at'))
+      end
+    end
+
+    describe 'query_schema' do
+      subject(:path_schema) { compiler.query_schema }
+
+      specify { expect { subject }.not_to raise_error }
+
+      describe 'for name' do
+        subject { path_schema.find { |p| p[:name] == :sort } }
+
+        it { should include(schema: include(type: :array)) }
+        it { should include(style: :form) }
+        it { should include(explode: false) }
+      end
+    end
+  end
+
   describe 'schema stub' do
     subject { described_class.new(type).schema_stub }
 

--- a/spec/sober_swag/compiler_spec.rb
+++ b/spec/sober_swag/compiler_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe SoberSwag::Compiler do
       it { should have_key('Classroom') }
       it { should_not have_key('') }
 
-      describe 'Classroom schema' do # rubocop:disable RSpec/NestedGroups
+      describe 'Classroom schema' do
         subject { schemas['Classroom'] }
 
         it { should_not be_nil }

--- a/spec/sober_swag/types/comma_array_spec.rb
+++ b/spec/sober_swag/types/comma_array_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe SoberSwag::Types::CommaArray do
+  describe 'parsing' do
+    context 'with a param integer' do
+      let(:type) { described_class.of(SoberSwag::Types::Params::Integer) }
+
+      shared_examples 'a good run' do
+        it { should eq([1, 2, 3]) }
+        specify { expect { subject }.not_to raise_error }
+      end
+
+      context 'with a good string' do
+        subject { type.call('1,2,3') }
+
+        it_behaves_like 'a good run'
+      end
+
+      context 'with a good array of strings' do
+        subject { type.call(%w[1 2 3]) }
+
+        it_behaves_like 'a good run'
+      end
+
+      context 'with a good array of integers' do
+        subject { type.call([1, 2, 3]) }
+
+        it_behaves_like 'a good run'
+      end
+
+      context 'with an empty string' do
+        subject { type.call('') }
+
+        specify { expect { subject }.not_to raise_error }
+        it { should be_empty }
+        it { should be_a(Array) }
+      end
+
+      context 'with a bad string' do
+        subject { type.call('no') }
+
+        specify { expect { subject }.to raise_error(Dry::Types::CoercionError) }
+      end
+    end
+
+    context 'with a sort-like enum' do
+      let(:type) { described_class.of(SoberSwag::Types::String.enum('created_at', 'updated_at', '-created_at', '-updated_at')) }
+
+      context 'with an empty string' do
+        subject { type.call('') }
+
+        specify { expect { subject }.not_to raise_error }
+        it { should be_empty }
+        it { should be_a(Array) }
+        it { should eq([]) }
+      end
+
+      context 'with a sort-ish string' do
+        subject { type.call('created_at, -updated_at') }
+
+        specify { expect { subject }.not_to raise_error }
+        it { should eq(%w[created_at -updated_at]) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows changing the `style` and `explode` properties of attributes for query and path parameters. It also adds a new type, `CommaArray`, which accepts *either* an actual array of comma-separated values (which it then parses into an array). This will fix #36 . 