### PR TITLE
Update some of the documentation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
     # uses: ruby/setup-ruby@v1
       uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
       with:
-        ruby-version:  ${{ matrix.ruby }}
+        ruby-version: ${{ matrix.ruby }}
     - uses: actions/cache@v2
       with:
         path: vendor/bundle

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,10 +40,8 @@ jobs:
       run: |
         bundle config path vendor/bundle
         bundle install
-        gem install rubocop
-        gem install rubocop-rspec
     - name: Run Lints
-      run: rubocop lib spec example
+      run: bundle exec rubocop -P
     - uses: actions/cache@v2
       with:
         path: example/vendor/bundle

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 Gemfile.lock
 
 *.gem
+
+/vendor/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,85 +1,123 @@
-Style/FrozenStringLiteralComment:
-  Enabled: false
-Style/BlockDelimiters:
-  EnforcedStyle: braces_for_chaining
+require: rubocop-rspec
+
 AllCops:
   TargetRubyVersion: 2.6.0
   Exclude:
     - 'bin/bundle'
     - 'example/bin/bundle'
+    - 'vendor/bundle/**/*'
 
 Layout/LineLength:
   Max: 160
-require: rubocop-rspec
+
 RSpec/NamedSubject:
   Enabled: false
+
 RSpec/DescribeClass:
   Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
     - 'sober_swag.gemspec'
     - 'example/spec/**/*.rb'
+
 RSpec/ImplicitBlockExpectation:
   Enabled: false
+
 RSpec/ImplicitExpect:
   EnforcedStyle: should
+
 RSpec/LeadingSubject:
   Enabled: false
+
 Style/MultilineBlockChain:
   Enabled: false
+
 Metrics/AbcSize:
   Enabled: false
+
 Style/Documentation:
   Exclude:
     - 'example/db/migrate/**/*'
+
 Metrics/PerceivedComplexity:
   Enabled: false
+
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true
+
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
+
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
+
 Lint/DuplicateElsifCondition:
   Enabled: true
+
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
+
 Lint/RaiseException:
   Enabled: true
+
 Lint/StructNewOverride:
   Enabled: true
+
 Style/AccessorGrouping:
   Enabled: true
+
 Style/ArrayCoercion:
   Enabled: true
+
 Style/BisectedAttrAccessor:
   Enabled: true
+
 Style/CaseLikeIf:
   Enabled: true
+
 Style/ExponentialNotation:
   Enabled: true
+
 Style/HashAsLastArrayItem:
   Enabled: true
+
 Style/HashEachMethods:
   Enabled: true
+
 Style/HashLikeCase:
   Enabled: true
+
 Style/HashTransformKeys:
   Enabled: true
+
 Style/HashTransformValues:
   Enabled: true
+
 Style/RedundantAssignment:
   Enabled: true
+
 Style/RedundantFetchBlock:
   Enabled: true
+
 Style/RedundantFileExtensionInRequire:
   Enabled: true
+
 Style/RedundantRegexpCharacterClass:
   Enabled: true
+
 Style/RedundantRegexpEscape:
   Enabled: true
+
 Style/SlicingWithRange:
   Enabled: true
+
 RSpec/NestedGroups:
   Max: 5
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/BlockDelimiters:
+  EnforcedStyle: braces_for_chaining

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ class PeopleController < ApplicationController
 end
 ```
 
-We can now use this information to generate swagger documentation, available at the `swagger` action on this controller.
 More than that, we can use this information *inside* our controller methods:
 
 ```ruby
@@ -43,6 +42,51 @@ end
 
 No need for `params.require` or anything like that.
 You define the type of parameters you accept, and we reject anything that doesn't fit.
+
+### Rendering Swagger documentation from SoberSwag
+
+We can also use the information from SoberSwag objects to generate Swagger
+documentation, available at the `swagger` action on this controller.
+
+You can create the `swagger` action for a controller as follows:
+
+```ruby
+# config/routes.rb
+Rails.application.routes.draw do
+  # Add a `swagger` GET endpoint to render the Swagger documentation created
+  # by SoberSwag.
+  resources :people do
+    get :swagger, on: :collection
+  end
+
+  # Or use a concern to make it easier to enable swagger endpoints for a number
+  # of controllers at once.
+  concern :swaggerable do
+    get :swagger, on: :collection
+  end
+
+  resources :people, concerns: :swaggerable do
+    get :search, on: :collection
+  end
+
+  resources :places, only: [:index], concerns: :swaggerable
+end
+```
+
+If you don't want the API documentation to show up in certain cases, you can
+use an environment variable or a check on the current Rails environment.
+
+```ruby
+# config/routes.rb
+Rails.application.routes.draw do
+  resources :people do
+    # Enable based on environment variable.
+    get :swagger, on: :collection if ENV['ENABLE_SWAGGER']
+    # Or just disable in production.
+    get :swagger, on: :collection unless Rails.env.production?
+  end
+end
+```
 
 ### Typed Responses
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This generates documentation from *types*, which (conveniently) also lets you ge
 
 An introductory presentation is available [here](https://www.icloud.com/keynote/0bxP3Dn8ETNO0lpsSQSVfEL6Q#SoberSwagPresentation).
 
+Further documentation on using the gem is available in the `docs/` directory:
+
+- [Serializers](docs/serializers.md)
+
 ## Types for a fully-automated API
 
 SoberSwag lets you type your API using describe blocks.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Use SoberSwag output objects, a serializer library heavily inspired by [Blueprin
 PersonOutputObject = SoberSwag::OutputObject.define do
   field :id, primitive(:Integer)
   field :name, primitive(:String).optional
+  # For fields that don't map to a simple attribute on your model, you can
+  # use a block.
   field :is_registered, primitive(:Bool) do |person|
     person.registered?
   end
@@ -139,7 +141,7 @@ User = SoberSwag.input_object do
   attribute :name, SoberSwag::Types::String
   # use ? if attributes are not required
   attribute? :favorite_movie, SoberSwag::Types::String
-  # use .optional if attributes may be null
+  # use .optional if attributes may be nil
   attribute :age, SoberSwag::Types::Params::Integer.optional
 end
 ```
@@ -163,6 +165,34 @@ end
 
 Under the hood, this literally just generates a subclass of `Dry::Struct`.
 We use the DSL-like method just to make working with Rails' reloading less annoying.
+
+#### Input and Output Object Identifiers
+
+Both input objects and output objects accept an identifier, which is used in
+the Swagger Documentation to disambiguate between SoberSwag types.
+
+```ruby
+User = SoberSwag.input_object do
+  identifier 'User'
+
+  attribute? :name, SoberSwag::Types::String
+end
+```
+
+```ruby
+PersonOutputObject = SoberSwag::OutputObject.define do
+  identifier 'PersonOutput'
+
+  field :id, primitive(:Integer)
+  field :name, primitive(:String).optional
+end
+```
+
+You can use these to make your Swagger documentation a bit easier to follow,
+and it can also be useful for 'namespacing' objects if you're developing in
+a large application, e.g. if you had a pet store and for some reason users
+with cats and users with dogs were different, you could namespace it with
+`identifier 'Dogs.User'`.
 
 #### Adding additional documentation
 

--- a/docs/serializers.md
+++ b/docs/serializers.md
@@ -25,21 +25,21 @@ For example, you might have a serializer that can return a date in two formats, 
 In this case, it might be used as:
 
 ```ruby
-serializer.new(my_record, { format: :newstyle })
+serializer.new(my_record, { format: :new_style })
 ```
 
 However, since it is *always* optional, you can also do:
 
 ```ruby
-serilaizer.new(my_record)
+serializer.new(my_record)
 ```
 
 And it *should* pick some default format.
 
 ### Primitives
 
-Primitive serializers, or "identity serializers," are serializers that do nothing.
-They are implemented as [`SoberSwag::Serializer::Primitive`](../lib/sober_swag/serializer/primitive.rb), or as the `#primitive` method on a `OutputObject`.
+Primitive serializers — or "identity serializers" — are serializers that do nothing.
+They are implemented as [`SoberSwag::Serializer::Primitive`](../lib/sober_swag/serializer/primitive.rb), or as the `#primitive` method on an `OutputObject`.
 Since they don't do anything, they can be considered the most "basic" serializer.
 
 These serializers *do not* check types.
@@ -51,12 +51,12 @@ serializer.serialize(10) # => 10
 ```
 
 Thus, care should be used when working with these serializers.
-In the future, we might add some "debug mode" sorta thing that will do type-checking and throw errors, however, the cost of doing so in production is probably not worth it.
+In the future, we might add some "debug mode" thing that will do type-checking and throw errors, however, the cost of doing so in production is probably not worth it.
 
 ### Mapped
 
 Sometimes, you can create a serializer via a *proc*.
-For example, let's say that I want a serializer that takes a `Date` and returns a string.
+For example, let's say that I want a serializer that takes a `Date` and returns a String.
 I can do this:
 
 ```ruby
@@ -74,7 +74,7 @@ In the future, we might add a debug mode.
 Oftentimes, we want to give a serializer the ability to serialize `nil` values.
 This is often useful in serializing fields.
 
-It turns out that it's pretty easy to make a serializer that can serialize `nil` values: just propogate nils.
+It turns out that it's pretty easy to make a serializer that can serialize `nil` values: just propogate `nil`s.
 For example, let's say I have the following code:
 
 ```ruby
@@ -99,7 +99,7 @@ Continuing our example from earlier:
 my_serializer.array.serialize([Foo.new(10, 11)]) #=> [{ bar: 10, baz: 11 }]
 ```
 
-This changes the type properly, too.
+This changes the type properly too.
 
 ## OutputObjects
 
@@ -132,7 +132,7 @@ end
 We can see a few things here:
 
 1. You define field names with a `field` definition, which is a way to define the serializer for a single field.
-2. You must provide types with field names
+2. You must provide types with field names.
 3. You can use blocks to do data formatting, which lets you pick different fields and such.
 
 
@@ -223,12 +223,12 @@ For clarity (and to prevent infinitely-looping serializers on accident, we recom
 Output objects don't support inheritance.
 You can't have one output object based on another.
 You *can*, however, merge one into another!
-Consdier this case:
+Consider this case:
 
 ```ruby
 GenericBioOutput = SoberSwag::OutputObject.define do
   field :name, primitive(:String)
-  field :brief_history, primtiive(:String)
+  field :brief_history, primitive(:String)
 end
 
 ExecutiveBioOutput = SoberSwag::OutputObject.define do
@@ -248,14 +248,16 @@ Identifiers and views will not be copied over.
 
 While defining a new Output Object, you *do not* have access to the definition of that output object.
 So, how do I say that one view should be an extension of another?
-Simple: use the `inherits:` kwarg:
+Simple, use the `inherits:` kwarg:
 
 ```ruby
 BioOutput = SoberSwag::OutputObject.define do
   field :name, primitive(:String)
+
   view :detail do
     field :bio, primitive(:String)
   end
+
   view :super_detail, inherits: :detail do
     field :age, primitive(:Integer)
   end
@@ -263,4 +265,4 @@ end
 ```
 
 `inherits` will automatically merge in all the fields of the referenced view.
-This means that the view `super_detail`  will include fields `name`, `bio`, and `age`.
+This means that the view `super_detail` will include fields `name`, `bio`, and `age`.

--- a/sober_swag.gemspec
+++ b/sober_swag.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'rubocop-rspec'
+  spec.add_development_dependency 'rubocop', '~> 0.93.1'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.44.1'
   spec.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
I didn't actually realize `docs/serializers.md` existed. I'd probably argue that a lot of it (e.g. views, inheritance, etc.) should be in the README rather than `serializers.md`, but that's just my opinion, man.

Anyway, I fixed a bunch of typos, linked to the `serializers.md` file from the README, added docs on the `swagger` actions in routing, and the `identifier` method (double-check that one because I may have yolo'd the docs that one a bit).