### PR TITLE
Enable tagging

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,10 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
     - uses: actions/cache@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,14 +20,10 @@ jobs:
     strategy:
       matrix:
         ruby: [ '2.6', '2.7' ]
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version:  ${{ matrix.ruby }}
     - uses: actions/cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## vNEXT
+
+- Allow tagging endpoints via the new `tags` method.
+
 ## [v0.16.0]: 2020-10-23
 
 - Allow non-class types to be used as the inputs to controllers

--- a/README.md
+++ b/README.md
@@ -268,6 +268,20 @@ QueryInput = SoberSwag.input_object do
 end
 ```
 
+## Tags
+
+If you want to organize your API into sections, you can use `tags`.
+It's quite simple:
+
+```ruby
+define :patch, :update, '/people/{id}' do
+  # other cool config
+  tags 'people', 'mutations', 'incurs_cost'
+end
+```
+
+This will map to OpenAPI's `tags` field (naturally), and the UI codegen will automatically organize your endpoints by their tags.
+
 ## Testing the validity of output objects
 
 If you're using RSpec and want to test the validity of output objects, you can do so relatively easily.

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    sober_swag (0.14.0)
+    sober_swag (0.16.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.2)

--- a/example/app/controllers/people_controller.rb
+++ b/example/app/controllers/people_controller.rb
@@ -35,6 +35,7 @@ class PeopleController < ApplicationController
     request_body(PersonParams)
     response(:ok, 'the person created', PersonOutputObject)
     response(:unprocessable_entity, 'the validation errors', PersonErrorsOutputObject)
+    tags 'people', 'create'
   end
   def create
     p = Person.new(parsed_body.person.to_h)
@@ -50,6 +51,7 @@ class PeopleController < ApplicationController
     path_params { attribute :id, Types::Params::Integer }
     response(:ok, 'the person updated', PersonOutputObject)
     response(:unprocessable_entity, 'the validation errors', PersonErrorsOutputObject)
+    tags 'people', 'update'
   end
   def update
     if @person.update(parsed_body.person.to_h)
@@ -68,6 +70,7 @@ class PeopleController < ApplicationController
       attribute :view, Types::String.default('base'.freeze).enum('base', 'detail')
     end
     response(:ok, 'all the people', PersonOutputObject.array)
+    tags 'people', 'list'
   end
   def index
     @people = Person.all
@@ -81,6 +84,7 @@ class PeopleController < ApplicationController
       attribute :id, Types::Params::Integer
     end
     response(:ok, 'the person requested', PersonOutputObject)
+    tags 'people', 'show'
   end
   def show
     respond!(:ok, @person)

--- a/example/app/controllers/posts_controller.rb
+++ b/example/app/controllers/posts_controller.rb
@@ -47,6 +47,7 @@ class PostsController < ApplicationController
       MARKDOWN
     end
     response(:ok, 'all the posts', PostOutputObject.array)
+    tags 'posts', 'list'
   end
   def index
     @posts = Post.all
@@ -60,6 +61,7 @@ class PostsController < ApplicationController
     path_params(ShowPath)
     query_params { attribute? :view, ViewTypes }
     response(:ok, 'the requested post', PostOutputObject)
+    tags 'posts', 'show'
   end
   def show
     respond!(:ok, @post, serializer_opts: { view: parsed_query.view })
@@ -68,6 +70,7 @@ class PostsController < ApplicationController
   define :post, :create, '/posts/' do
     request_body(PostCreate)
     response(:created, 'the created post', PostOutputObject)
+    tags 'posts', 'create'
   end
   def create
     @post = Post.new(parsed_body.post.to_h)
@@ -83,6 +86,7 @@ class PostsController < ApplicationController
     path_params(ShowPath)
     request_body(PostUpdate)
     response(:ok, 'the post updated', PostOutputObject.view(:base))
+    tags 'posts', 'update'
   end
   def update
     if @post.update(parsed_body.post.to_h)
@@ -95,6 +99,7 @@ class PostsController < ApplicationController
   define :delete, :destroy, '/posts/{id}' do
     path_params(ShowPath)
     response(:ok, 'the post deleted', PostOutputObject.view(:base))
+    tags 'posts', 'delete'
   end
   def destroy
     @post.destroy

--- a/lib/sober_swag/compiler/path.rb
+++ b/lib/sober_swag/compiler/path.rb
@@ -21,6 +21,7 @@ module SoberSwag
         base[:parameters] = params if params.any?
         base[:responses] = responses
         base[:requestBody] = request_body if request_body
+        base[:tags] = tags if tags
         base
       end
 
@@ -71,6 +72,12 @@ module SoberSwag
             }
           }
         }
+      end
+
+      def tags
+        return nil unless route.tags.any?
+
+        route.tags
       end
     end
   end

--- a/lib/sober_swag/controller/route.rb
+++ b/lib/sober_swag/controller/route.rb
@@ -9,6 +9,7 @@ module SoberSwag
         @action_name = action_name
         @response_serializers = {}
         @response_descriptions = {}
+        @tags = []
       end
 
       attr_reader :response_serializers, :response_descriptions, :controller, :method, :path, :action_name
@@ -22,6 +23,12 @@ module SoberSwag
       ##
       # What to parse the path params into.
       attr_reader :path_params_class
+
+      def tags(*args)
+        return @tags if args.empty?
+
+        @tags = args.flatten
+      end
 
       ##
       # Define the request body, using SoberSwag's type-definition scheme.

--- a/lib/sober_swag/controller/route.rb
+++ b/lib/sober_swag/controller/route.rb
@@ -24,6 +24,8 @@ module SoberSwag
       # What to parse the path params into.
       attr_reader :path_params_class
 
+      ##
+      # Standard swagger tags.
       def tags(*args)
         return @tags if args.empty?
 


### PR DESCRIPTION
This PR adds the ability to tag routes, for better organization of API documentation. 