### PR TITLE
PE-7270: Add generic hash

### DIFF
--- a/lib/sober_swag/compiler/primitive.rb
+++ b/lib/sober_swag/compiler/primitive.rb
@@ -39,7 +39,7 @@ module SoberSwag
 
       DATE_PRIMITIVE = { type: :string, format: :date }.freeze
       DATE_TIME_PRIMITIVE = { type: :string, format: :'date-time' }.freeze
-      HASH_PRIMATIVE = { type: :object, additionalProperties: true }.freeze
+      HASH_PRIMITIVE = { type: :object, additionalProperties: true }.freeze
 
       SWAGGER_PRIMITIVE_DEFS =
         {
@@ -54,7 +54,7 @@ module SoberSwag
           Date => DATE_PRIMITIVE,
           DateTime => DATE_TIME_PRIMITIVE,
           Time => DATE_TIME_PRIMITIVE,
-          Hash => HASH_PRIMATIVE
+          Hash => HASH_PRIMITIVE
         ).transform_values(&:freeze).freeze
 
       def ref_name

--- a/lib/sober_swag/compiler/primitive.rb
+++ b/lib/sober_swag/compiler/primitive.rb
@@ -39,6 +39,7 @@ module SoberSwag
 
       DATE_PRIMITIVE = { type: :string, format: :date }.freeze
       DATE_TIME_PRIMITIVE = { type: :string, format: :'date-time' }.freeze
+      HASH_PRIMATIVE = { type: :object, additionalProperties: true }.freeze
 
       SWAGGER_PRIMITIVE_DEFS =
         {
@@ -52,7 +53,8 @@ module SoberSwag
         .to_h.merge(
           Date => DATE_PRIMITIVE,
           DateTime => DATE_TIME_PRIMITIVE,
-          Time => DATE_TIME_PRIMITIVE
+          Time => DATE_TIME_PRIMITIVE,
+          Hash => HASH_PRIMATIVE
         ).transform_values(&:freeze).freeze
 
       def ref_name

--- a/spec/sober_swag/compiler/primitive_spec.rb
+++ b/spec/sober_swag/compiler/primitive_spec.rb
@@ -30,4 +30,12 @@ RSpec.describe SoberSwag::Compiler::Primitive do
     it { should_not be_named }
     it { should have_attributes(type_hash: { type: :string, format: :'date-time' }) }
   end
+
+  context 'with a hash' do
+    let(:type) { Hash }
+
+    it { should be_swagger_primitive }
+    it { should_not be_named }
+    it { should have_attributes(type_hash: { type: :object, additionalProperties: true }) }
+  end
 end


### PR DESCRIPTION
This allows us to define a generic hash instead of throwing an error when using Hash types