### PR TITLE
Adds option to #merge for excluding specified fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [vNEXT]
+
+- Added `except` parameter to the `merge` method, which allows a specified field to be excluded from the merge.
+
 ## NEXT
 
 - Added YARD documentation to almost every method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,9 @@
 # Changelog
 
-## [vNEXT]
-
-- Added `except` parameter to the `merge` method, which allows a specified field to be excluded from the merge.
-
 ## NEXT
 
 - Added YARD documentation to almost every method
-
+- Added `except` parameter to the `merge` method, which allows a specified field to be excluded from the merge.
 ## [v0.19.0] 2021-03-10
 
 - Use [redoc](https://github.com/Redocly/redoc) for generated documentation UI

--- a/docs/serializers.md
+++ b/docs/serializers.md
@@ -241,6 +241,9 @@ end
 Using `#merge` lets you add in all the fields from one output object into another.
 You can even use `merge` from within a view.
 
+Exclude any unneeded fields from the merge by passing a hash:
+`merge GenericBioOutput, { except: [:position] }`
+
 Note that `merge` does *not* copy anything but fields.
 Identifiers and views will not be copied over.
 

--- a/lib/sober_swag/output_object/field_syntax.rb
+++ b/lib/sober_swag/output_object/field_syntax.rb
@@ -37,11 +37,11 @@ module SoberSwag
       # Note that merging in a full output object *will not* also merge in views, just fields defined on the base.
       #
       # @param other [#fields] a field container, like a {SoberSwag::OutputObject} or something
-      # @param opts [Hash] accepts a key of :except to optionally exclude a field from the output object being merged
+      # @param except [Array<Symbol>] optionally exclude a field from the output object being merged
       # @return [void]
-      def merge(other, opts = {})
+      def merge(other, except: [])
         other.fields.each do |field|
-          add_field!(field) unless opts.fetch(:except, []).include?(field.name)
+          add_field!(field) unless except.include?(field.name)
         end
       end
     end

--- a/lib/sober_swag/output_object/field_syntax.rb
+++ b/lib/sober_swag/output_object/field_syntax.rb
@@ -37,10 +37,11 @@ module SoberSwag
       # Note that merging in a full output object *will not* also merge in views, just fields defined on the base.
       #
       # @param other [#fields] a field container, like a {SoberSwag::OutputObject} or something
+      # @param opts [Hash] accepts a key of :except to optionally exclude a field from the output object being merged
       # @return [void]
-      def merge(other)
+      def merge(other, opts = {})
         other.fields.each do |field|
-          add_field!(field)
+          add_field!(field) unless opts.fetch(:except, []).include?(field.name)
         end
       end
     end

--- a/spec/sober_swag/output_object/merge_spec.rb
+++ b/spec/sober_swag/output_object/merge_spec.rb
@@ -10,21 +10,41 @@ RSpec.describe 'merging SoberSwag output objects' do
   end
 
   context 'when merged into a blueprint' do
-    subject { example.serialize({ id: 10, name: 'Bob', items: 10 }) }
+    context 'without exceptions' do
+      subject { example.serialize({ id: 10, name: 'Bob', items: 10 }) }
 
-    let(:example) do
-      bp = base
-      SoberSwag::OutputObject.define do
-        merge bp
+      let(:example) do
+        bp = base
+        SoberSwag::OutputObject.define do
+          merge bp
 
-        field :items, primitive(:Integer)
+          field :items, primitive(:Integer)
+        end
       end
+
+      specify { expect { subject }.not_to raise_error }
+      it { should have_key(:id) }
+      it { should have_key(:name) }
+      it { should have_key(:items) }
     end
 
-    specify { expect { subject }.not_to raise_error }
-    it { should have_key(:id) }
-    it { should have_key(:name) }
-    it { should have_key(:items) }
+    context 'with exceptions' do
+      subject { example.serialize({ id: 10, name: 'Bob', items: 10 }) }
+
+      let(:example) do
+        bp = base
+        SoberSwag::OutputObject.define do
+          merge(bp, { except: [:id] })
+
+          field :items, primitive(:Integer)
+        end
+      end
+
+      specify { expect { subject }.not_to raise_error }
+      it { should_not have_key(:id) }
+      it { should have_key(:name) }
+      it { should have_key(:items) }
+    end
   end
 
   context 'when merged into a view' do

--- a/spec/sober_swag/output_object/merge_spec.rb
+++ b/spec/sober_swag/output_object/merge_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'merging SoberSwag output objects' do
       let(:example) do
         bp = base
         SoberSwag::OutputObject.define do
-          merge(bp, { except: [:id] })
+          merge(bp, except: [:id])
 
           field :items, primitive(:Integer)
         end


### PR DESCRIPTION
This PR adds an options hash to the merge method so that specified fields can be excluded from the merge.