### PR TITLE
Improve generated docs

### DIFF
--- a/lib/sober_swag/reporting/input.rb
+++ b/lib/sober_swag/reporting/input.rb
@@ -14,6 +14,7 @@ module SoberSwag
       autoload :Format, 'sober_swag/reporting/input/format'
       autoload :Number, 'sober_swag/reporting/input/number'
       autoload :Interface, 'sober_swag/reporting/input/interface'
+      autoload :InRange, 'sober_swag/reporting/input/in_range'
       autoload :List, 'sober_swag/reporting/input/list'
       autoload :Mapped, 'sober_swag/reporting/input/mapped'
       autoload :MergeObjects, 'sober_swag/reporting/input/merge_objects'

--- a/lib/sober_swag/reporting/input.rb
+++ b/lib/sober_swag/reporting/input.rb
@@ -16,6 +16,7 @@ module SoberSwag
       autoload :Interface, 'sober_swag/reporting/input/interface'
       autoload :InRange, 'sober_swag/reporting/input/in_range'
       autoload :List, 'sober_swag/reporting/input/list'
+      autoload :MultipleOf, 'sober_swag/reporting/input/multiple_of'
       autoload :Mapped, 'sober_swag/reporting/input/mapped'
       autoload :MergeObjects, 'sober_swag/reporting/input/merge_objects'
       autoload :Null, 'sober_swag/reporting/input/null'

--- a/lib/sober_swag/reporting/input/in_range.rb
+++ b/lib/sober_swag/reporting/input/in_range.rb
@@ -1,0 +1,61 @@
+module SoberSwag
+  module Reporting
+    module Input
+      ##
+      # Specify that an item must be within a given range in ruby.
+      # This gets translated to `minimum` and `maximum` keys in swagger.
+      #
+      # This works with endless ranges (Ruby 2.6+) and beginless ranges (Ruby 2.7+)
+      class InRange < Base
+        def initialize(input, range)
+          @input = input
+          @range = range
+        end
+
+        ##
+        # @return [Interface]
+        attr_reader :input
+
+        ##
+        # @return [Range]
+        attr_reader :range
+
+        ##
+        # @return [Range]
+        def call(value)
+          res = input.call(value)
+
+          return res if res.is_a?(Report::Base)
+          return Report::Value.new(['was not in minimum/maximum range']) unless range.member?(res)
+
+          res
+        end
+
+        def swagger_schema
+          schema, found = input.swagger_schema
+
+          merged =
+            if schema.key?(:$ref)
+              { allOf: [schema] }
+            else
+              schema
+            end.merge(maximum_portion).merge(minimum_portion)
+
+          [merged, found]
+        end
+
+        def maximum_portion
+          return {} unless range.end
+
+          { maximum: range.end, exclusiveMaximum: range.exclude_end? }
+        end
+
+        def minimum_portion
+          return {} unless range.begin
+
+          { minimum: range.begin, exclusiveMinimum: false }
+        end
+      end
+    end
+  end
+end

--- a/lib/sober_swag/reporting/input/interface.rb
+++ b/lib/sober_swag/reporting/input/interface.rb
@@ -35,6 +35,15 @@ module SoberSwag
           List.new(self)
         end
 
+        ##
+        # Constrained values: must be in range.
+        # @return [InRange]
+        def in_range(range)
+          raise ArgumentError, "need a range, not a #{range.class}" unless range.is_a?(Range)
+
+          InRange.new(self, range)
+        end
+
         def referenced(name)
           Referenced.new(self, name)
         end

--- a/lib/sober_swag/reporting/input/interface.rb
+++ b/lib/sober_swag/reporting/input/interface.rb
@@ -44,6 +44,12 @@ module SoberSwag
           InRange.new(self, range)
         end
 
+        ##
+        # Constrained values: must be a multiple of the given number
+        def multiple_of(number)
+          MultipleOf.new(self, number)
+        end
+
         def referenced(name)
           Referenced.new(self, name)
         end
@@ -81,6 +87,17 @@ module SoberSwag
 
         def swagger_query_schema
           raise InvalidSchemaError::InvalidForQueryError.new(self) # rubocop:disable Style/RaiseArgs
+        end
+
+        def modify_schema(base, addition)
+          schema, found = base.swagger_schema
+          merged =
+            if schema.key?(:$ref)
+              { allOf: [schema] }
+            else
+              schema
+            end.merge(addition)
+          [merged, found]
         end
 
         def add_schema_key(base, addition)

--- a/lib/sober_swag/reporting/input/multiple_of.rb
+++ b/lib/sober_swag/reporting/input/multiple_of.rb
@@ -1,0 +1,36 @@
+module SoberSwag
+  module Reporting
+    module Input
+      ##
+      # Adds the multipleOf constraint to input types.
+      # Will use the '%' operator to calculate this, which may behave oddly for floats.
+      class MultipleOf < Base
+        def initialize(input, mult)
+          @input = input
+          @mult = mult
+        end
+
+        ##
+        # @return [Interface]
+        attr_reader :input
+
+        ##
+        # @return [Numeric]
+        attr_reader :mult
+
+        def call(value)
+          parsed = input.call(value)
+
+          return parsed if parsed.is_a?(Report::Base)
+          return Report::Value.new(["was not a multiple of #{mult}"]) unless (parsed % mult).zero?
+
+          parsed
+        end
+
+        def swagger_schema
+          modify_schema(input, { multipleOf: mult })
+        end
+      end
+    end
+  end
+end

--- a/lib/sober_swag/reporting/input/object.rb
+++ b/lib/sober_swag/reporting/input/object.rb
@@ -65,7 +65,7 @@ module SoberSwag
         end
 
         def field_schemas
-          fields.reduce([{}, Set.new]) do |(field_schemas, found), (k, v)|
+          fields.reduce([{}, {}]) do |(field_schemas, found), (k, v)|
             key_schema, key_found = v.property_schema
             [
               field_schemas.merge(k => key_schema),

--- a/lib/sober_swag/reporting/output.rb
+++ b/lib/sober_swag/reporting/output.rb
@@ -15,6 +15,7 @@ module SoberSwag
       autoload(:MergeObjects, 'sober_swag/reporting/output/merge_objects')
       autoload(:Null, 'sober_swag/reporting/output/null')
       autoload(:Number, 'sober_swag/reporting/output/number')
+      autoload(:Enum, 'sober_swag/reporting/output/enum')
       autoload(:Object, 'sober_swag/reporting/output/object')
       autoload(:Partitioned, 'sober_swag/reporting/output/partitioned')
       autoload(:Pattern, 'sober_swag/reporting/output/pattern')

--- a/lib/sober_swag/reporting/output/enum.rb
+++ b/lib/sober_swag/reporting/output/enum.rb
@@ -1,0 +1,47 @@
+module SoberSwag
+  module Reporting
+    module Output
+      ##
+      # Models outputting an enum.
+      class Enum < Base
+        def initialize(output, values)
+          @output = output
+          @values = values
+        end
+
+        ##
+        # @return [Interface]
+        attr_reader :output
+
+        ##
+        # @return [Array]
+        attr_reader :values
+
+        def call(value)
+          output.call(value)
+        end
+
+        def serialize_report(value)
+          rep = output.serialize_report(value)
+
+          return rep if rep.is_a?(Report::Base)
+
+          return Report::Value.new(['was not an acceptable enum member']) unless values.include?(rep)
+
+          rep
+        end
+
+        def swagger_schema
+          schema, found = output.swagger_schema
+          merged =
+            if schema.key?(:$ref)
+              { allOf: [schema] }
+            else
+              schema
+            end.merge(enum: values)
+          [merged, found]
+        end
+      end
+    end
+  end
+end

--- a/lib/sober_swag/reporting/output/interface.rb
+++ b/lib/sober_swag/reporting/output/interface.rb
@@ -30,6 +30,12 @@ module SoberSwag
           ViaMap.new(self, block)
         end
 
+        ##
+        # @return [SoberSwag::Reporting::Output::Enum]
+        def enum(*cases)
+          Enum.new(self, cases)
+        end
+
         def referenced(name)
           Referenced.new(self, name)
         end

--- a/spec/sober_swag/reporting/input/in_range_spec.rb
+++ b/spec/sober_swag/reporting/input/in_range_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe SoberSwag::Reporting::Input::InRange do
+  context 'with a simple integer range that excludes end' do
+    subject(:input) { described_class.new(SoberSwag::Reporting::Input.number, (1...3)) }
+
+    it { should parse_input(1) }
+    it { should parse_input(2) }
+    it { should report_on_input(0) }
+    it { should report_on_input(3) }
+
+    describe '#swagger_schema[0]' do
+      subject { input.swagger_schema[0] }
+
+      its([:minimum]) { should eq 1 }
+      its([:exclusiveMinimum]) { should be_nil | eq(false) }
+      its([:maximum]) { should eq 3 }
+      its([:exclusiveMaximum]) { should eq(true) }
+    end
+  end
+end

--- a/spec/sober_swag/reporting/input/multiple_of_spec.rb
+++ b/spec/sober_swag/reporting/input/multiple_of_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe SoberSwag::Reporting::Input::MultipleOf do
+  context 'with a multiple of 2' do
+    subject(:input) { SoberSwag::Reporting::Input.number.multiple_of(2) }
+
+    it { should parse_input(2) }
+    it { should parse_input(4) }
+    it { should report_on_input(1) }
+    it { should report_on_input(3.5) }
+
+    its(:swagger_schema) { should all(be_a(Hash)) }
+
+    describe '#swagger_schema[0]' do
+      subject { input.swagger_schema[0] }
+
+      its([:multipleOf]) { should eq 2 }
+    end
+  end
+end

--- a/spec/sober_swag/reporting/input/object_spec.rb
+++ b/spec/sober_swag/reporting/input/object_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe SoberSwag::Reporting::Input::Object do
+  context 'when empty' do
+    subject(:input) { described_class.new({}) }
+
+    it { should parse_input({}).to({}) }
+    it { should parse_input({ foo: 'bar' }).to({}) }
+
+    describe '#swagger_schema' do
+      subject { input.swagger_schema }
+
+      its([0]) { should be_a(Hash) }
+      its([1]) { should be_a(Hash) }
+    end
+  end
+end

--- a/spec/sober_swag/reporting/output/enum_spec.rb
+++ b/spec/sober_swag/reporting/output/enum_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe SoberSwag::Reporting::Output::Enum do
+  context 'with strings of either "bob" or "joe"' do
+    subject(:serializer) do
+      described_class.new(SoberSwag::Reporting::Output.text, %w[bob joe])
+    end
+
+    it { should serialize_output('bob') }
+    it { should serialize_output('joe') }
+    it { should report_on_output('rich evans') }
+    its(:swagger_schema) { should be_a(Array) & all(be_a(Hash)) }
+  end
+end


### PR DESCRIPTION
This:

1. Fixes a bug when generating documentation of output objects
2. Adds on a few more input types

I was going to add on *even more* input types, but realized that would better be left for other PRs. So you only get a few.