### PR TITLE
Add minimum and maximum for reporting output objects

### DIFF
--- a/lib/sober_swag/reporting/output.rb
+++ b/lib/sober_swag/reporting/output.rb
@@ -10,6 +10,7 @@ module SoberSwag
       autoload(:Defer, 'sober_swag/reporting/output/defer')
       autoload(:Described, 'sober_swag/reporting/output/described')
       autoload(:Dictionary, 'sober_swag/reporting/output/dictionary')
+      autoload(:InRange, 'sober_swag/reporting/output/in_range')
       autoload(:Interface, 'sober_swag/reporting/output/interface')
       autoload(:List, 'sober_swag/reporting/output/list')
       autoload(:MergeObjects, 'sober_swag/reporting/output/merge_objects')

--- a/lib/sober_swag/reporting/output/in_range.rb
+++ b/lib/sober_swag/reporting/output/in_range.rb
@@ -27,7 +27,7 @@ module SoberSwag
 
           return rep if rep.is_a?(Report::Base)
 
-          return Report::Value.new(['was not in minimum/maximum range']) unless range.member?(rep) 
+          return Report::Value.new(['was not in minimum/maximum range']) unless range.member?(rep)
 
           rep
         end
@@ -35,7 +35,7 @@ module SoberSwag
         def swagger_schema
           schema, found = output.swagger_schema
 
-          merged = 
+          merged =
             if schema.key?(:$ref)
               { allOf: [schema] }
             else

--- a/lib/sober_swag/reporting/output/in_range.rb
+++ b/lib/sober_swag/reporting/output/in_range.rb
@@ -1,0 +1,64 @@
+module SoberSwag
+  module Reporting
+    module Output
+      ##
+      # Specify that an output will be within a certain range.
+      # This gets translated to `minimum` and `maximum` keys in swagger.
+      class InRange < Base
+        def initialize(output, range)
+          @output = output
+          @range = range
+        end
+
+        ##
+        # @return [Interface]
+        attr_reader :output
+
+        ##
+        # @return [Range]
+        attr_reader :range
+
+        def call(value)
+          output.call(value)
+        end
+
+        def serialize_report(value)
+          rep = output.serialize_report(value)
+
+          return rep if rep.is_a?(Report::Base)
+
+          return Report::Value.new(['was not in minimum/maximum range']) unless range.member?(rep) 
+
+          rep
+        end
+
+        def swagger_schema
+          schema, found = output.swagger_schema
+
+          merged = 
+            if schema.key?(:$ref)
+              { allOf: [schema] }
+            else
+              schema
+            end.merge(maximum_portion).merge(minimum_portion)
+
+          [merged, found]
+        end
+
+        def maximum_portion
+          return {} unless range.end
+
+          res = { maximum: range.end }
+          res[:exclusiveMaximum] = true if range.exclude_end?
+          res
+        end
+
+        def minimum_portion
+          return {} unless range.begin
+
+          { minimum: range.begin }
+        end
+      end
+    end
+  end
+end

--- a/lib/sober_swag/reporting/output/interface.rb
+++ b/lib/sober_swag/reporting/output/interface.rb
@@ -40,6 +40,15 @@ module SoberSwag
           Referenced.new(self, name)
         end
 
+        ##
+        # @return [SoberSwag::Reporting::Output::InRange]
+        # Constrained values: must be within the given range.
+        def in_range(range)
+          raise ArgumentError, 'need a range' unless range.is_a?(Range)
+
+          InRange.new(self, range)
+        end
+
         def list
           List.new(self)
         end

--- a/spec/sober_swag/reporting/output/in_range_spec.rb
+++ b/spec/sober_swag/reporting/output/in_range_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe SoberSwag::Reporting::Output::InRange do
+  context 'with a basic range that excludes end' do
+    subject(:output) { described_class.new(SoberSwag::Reporting::Output.number, (1...3)) }
+
+    it { should serialize_output(1) }
+    it { should serialize_output(2) }
+    it { should report_on_output(0) }
+    it { should report_on_output(3) }
+
+    describe 'swagger_schema' do
+      subject { output.swagger_schema[0] }
+
+      its([:minimum]) { should eq 1 }
+      its([:exclusiveMinimum]) { should be_nil | eq(false) }
+      its([:maximum]) { should eq 3 }
+      its([:exclusiveMaximum]) { should eq true }
+    end
+  end
+
+  context 'with a range with no maximum' do
+    subject(:output) { described_class.new(SoberSwag::Reporting::Output.number, (0..)) }
+
+    it { should serialize_output(0) }
+    it { should serialize_output(1) }
+    it { should report_on_output(-1) }
+
+    describe 'swagger_schema' do
+      subject { output.swagger_schema[0] }
+
+      its([:minimum]) { should eq 0 }
+      its([:exclusiveMinimum]) { should be_nil | eq(false) }
+      its([:maximum]) { should be_nil }
+      its([:exclusiveMaximum]) { should be_nil }
+    end
+  end
+end


### PR DESCRIPTION
Addresses #108. Adds the ability to specify `minimum` and `maximum` for `SoberSwag::Reporting::Output` objects.