### PR TITLE
Add qol features

### DIFF
--- a/lib/sober_swag/input_object.rb
+++ b/lib/sober_swag/input_object.rb
@@ -42,6 +42,7 @@ module SoberSwag
       #   @param type the attribute type
       def attribute(key, parent = SoberSwag::InputObject, &block)
         raise ArgumentError, "parent class #{parent} is not an input object type!" unless valid_field_def?(parent, block)
+        raise ArgumentError, "cannot mix reporting and non-reporting types at attribute #{key}" if parent.is_a?(SoberSwag::Reporting::Input::Interface)
 
         super(key, parent, &block)
       end

--- a/lib/sober_swag/output_object/field_syntax.rb
+++ b/lib/sober_swag/output_object/field_syntax.rb
@@ -11,6 +11,8 @@ module SoberSwag
       # @param from [Symbol] method name to extract this field from, for convenience.
       # @param block [Proc] optional way to extract this field.
       def field(name, serializer, from: nil, &block)
+        raise ArgumentError, "do not mix reporting and non-reporting outputs (at key #{name})" if serializer.is_a?(SoberSwag::Reporting::Output::Interface)
+
         add_field!(Field.new(name, serializer, from: from, &block))
       end
 

--- a/lib/sober_swag/reporting/input/struct.rb
+++ b/lib/sober_swag/reporting/input/struct.rb
@@ -76,6 +76,7 @@ module SoberSwag
           #
           def add_attribute!(name, input, required:, description: nil)
             raise ArgumentError, 'name must be a symbol' unless name.is_a?(Symbol)
+            raise ArgumentError, 'input type must be a SoberSwag::Reporting::Input::Interface' unless input.is_a?(Interface)
 
             define_attribute(name) # defines an instance method to access this attribute
 

--- a/lib/sober_swag/reporting/output/struct.rb
+++ b/lib/sober_swag/reporting/output/struct.rb
@@ -20,6 +20,8 @@ module SoberSwag
           #
           #   You can access other methods from this method.
           def field(name, output, description: nil, &extract)
+            raise ArgumentError, "output of field #{name} is not a SoberSwag::Reporting::Output::Interface" unless output.is_a?(Interface)
+
             define_field(name, extract)
 
             object_fields[name] = Object::Property.new(

--- a/lib/sober_swag/reporting/output/struct.rb
+++ b/lib/sober_swag/reporting/output/struct.rb
@@ -158,22 +158,20 @@ module SoberSwag
           # @param name [Symbol] name of this view.
           # @yieldself [self] a block in which you can add more fields to the view.
           # @return [Class]
-          def define_view(name, &block) # rubocop:disable Metrics/MethodLength
-            raise ArgumentError, "duplicate view #{name}" if name == :base || views.include?(name)
+          def define_view(name, &block)
+            define_view_with_parent(name, self, block)
+          end
 
-            classy_name = name.to_s.classify
-
-            Class.new(self).tap do |c|
-              c.instance_eval(&block)
-              c.define_singleton_method(:define_view) do |*|
-                raise ArgumentError, 'no nesting views'
-              end
-              c.define_singleton_method(:identifier) do
-                [parent_struct.identifier, classy_name.gsub('::', '.')].join('.')
-              end
-              const_set(classy_name, c)
-              view_map[name] = c
-            end
+          ##
+          # Defines a view for this object, which "inherits" another view.
+          # @see #define_view for how views behave.
+          #
+          # @param name [Symbol] name of this view
+          # @param inherits [Symbol] name of the view this view inherits
+          # @yieldself [self] a block in which you can add more fields to this view
+          # @return [Class]
+          def define_inherited_view(name, inherits:, &block)
+            define_view_with_parent(name, view_class(inherits), block)
           end
 
           ##
@@ -197,6 +195,16 @@ module SoberSwag
             return inherited_output if name == :base
 
             view_map.fetch(name).view(:base)
+          end
+
+          ##
+          # Equivalent to .view, but returns the raw view class.
+          #
+          # @return [Class]
+          def view_class(name)
+            return self if name == :base
+
+            view_map.fetch(name)
           end
 
           attr_accessor :parent_struct
@@ -225,6 +233,21 @@ module SoberSwag
           end
 
           private
+
+          def define_view_with_parent(name, parent, block)
+            raise ArgumentError, "duplicate view #{name}" if name == :base || views.include?(name)
+
+            classy_name = name.to_s.classify
+            us = self # grab this so its identifier doesn't get nested under whatever parent it inherits from, since its our view
+
+            Class.new(parent).tap do |c|
+              c.instance_eval(&block)
+              c.define_singleton_method(:define_view) { |*| raise ArgumentError, 'no nesting views' }
+              c.define_singleton_method(:identifier) { [us.identifier, classy_name.gsub('::', '.')].join('.') }
+              const_set(classy_name, c)
+              view_map[name] = c
+            end
+          end
 
           def identified_view_map
             view_map.transform_values(&:identified_without_base).merge(base: inherited_output)

--- a/spec/sober_swag/input_object_spec.rb
+++ b/spec/sober_swag/input_object_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe SoberSwag::InputObject do
     end
   end
 
+  describe 'illegal mixing of reporting and non-reporting' do
+    it 'raises an error when you try to do this' do
+      expect {
+        SoberSwag.input_object do
+          identifier 'illegal'
+          attribute :bar, SoberSwag::Reporting::Input::Text.new
+        end
+      }.to raise_error(ArgumentError, /mix reporting/)
+    end
+  end
+
   describe '.type_attribute' do
     let(:accept) do
       SoberSwag.input_object do

--- a/spec/sober_swag/output_object/basic_spec.rb
+++ b/spec/sober_swag/output_object/basic_spec.rb
@@ -42,4 +42,14 @@ RSpec.describe 'a basic SoberSwag::OutputObject' do
       expect(roundtripped).to be_a(output_object.base.type)
     end
   end
+
+  describe 'bad definitions' do
+    it 'does not allow you to use a SoberSwag::Reporting::Output as a field def' do
+      expect {
+        SoberSwag::OutputObject.define do
+          field :foo, SoberSwag::Reporting::Output.text
+        end
+      }.to raise_error(ArgumentError, /non-reporting/)
+    end
+  end
 end

--- a/spec/sober_swag/reporting/input/struct_spec.rb
+++ b/spec/sober_swag/reporting/input/struct_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe SoberSwag::Reporting::Input::Struct do
     end
   end
 
+  describe 'illegal mixing of non-reporting and reporting types' do
+    it 'raises an error' do
+      expect {
+        Class.new(described_class) do
+          attribute :first_name, SoberSwag::Types::String
+        end
+      }.to raise_error(ArgumentError, /must be a/)
+    end
+  end
+
   context 'with a basic first/last name' do
     subject { struct_class }
 

--- a/spec/sober_swag/reporting/output/struct_spec.rb
+++ b/spec/sober_swag/reporting/output/struct_spec.rb
@@ -8,22 +8,26 @@ RSpec.describe SoberSwag::Reporting::Output::Struct do
       Class.new(described_class) do
         identifier 'Person'
 
-        field(:first_name, SoberSwag::Reporting::Output::Text.new)
-        field(:last_name, SoberSwag::Reporting::Output::Text.new)
+        field(:first_name, SoberSwag::Reporting::Output.text)
+        field(:last_name, SoberSwag::Reporting::Output.text)
 
         define_view :detail do
           field(
             :initials,
-            SoberSwag::Reporting::Output::Text.new,
+            SoberSwag::Reporting::Output.text,
             description: 'does not handle hyphenation, consider this deprecated please'
           ) do |o|
             [o.first_name, o.last_name].map { |i| "#{i[0..0]}." }.join(' ')
           end
         end
+
+        define_inherited_view :ultra_detail, inherits: :detail do
+          field(:first_name_length, SoberSwag::Reporting::Output.number) { |o| o.first_name.length }
+        end
       end
     end
 
-    its(:views) { should contain_exactly(:base, :detail) }
+    its(:views) { should contain_exactly(:base, :detail, :ultra_detail) }
     it { should serialize_output(input_type.new('Bob', 'Smith')).to({ first_name: 'Bob', last_name: 'Smith' }) }
 
     describe 'swagger direct schema' do
@@ -74,8 +78,7 @@ RSpec.describe SoberSwag::Reporting::Output::Struct do
       end
 
       it { should be_a(Hash) }
-      its(:length) { should eq 3 }
-      its(:keys) { should contain_exactly('Person', 'Person.Base', 'Person.Detail') }
+      its(:keys) { should contain_exactly('Person', 'Person.Base', 'Person.Detail', 'Person.Detail.Base', 'Person.UltraDetail') }
 
       describe 'root Person key' do
         subject(:base) { references['Person'] }
@@ -107,6 +110,18 @@ RSpec.describe SoberSwag::Reporting::Output::Struct do
 
           it { should include("$ref": end_with('Person.Base')) }
           it { should include(include(type: 'object', properties: be_key(:initials))) }
+        end
+      end
+
+      describe 'Person.UltraDetail' do
+        subject(:base) { references['Person.UltraDetail'] }
+
+        it { should be_key(:allOf) }
+
+        describe '[:allOf]' do
+          subject { base[:allOf] }
+
+          it { should include("$ref": end_with('Person.Detail.Base')) }
         end
       end
     end

--- a/spec/sober_swag/reporting/output/struct_spec.rb
+++ b/spec/sober_swag/reporting/output/struct_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 RSpec.describe SoberSwag::Reporting::Output::Struct do
+  describe 'illegal mixing of reporting and non-reporting' do
+    it 'raises an error' do
+      expect {
+        Class.new(described_class) do
+          field :first_name, SoberSwag::Serializer.primitive(SoberSwag::Types::String)
+        end
+      }.to raise_error(ArgumentError, /Interface/)
+    end
+  end
+
   context 'with an output with views' do
     let(:input_type) { Struct.new(:first_name, :last_name) }
 


### PR DESCRIPTION
Adds some quality of life features, including:

1. `define_inherited_view`, for defining a view on an output object more nicely.
2. Exceptions for:
    - Trying to use a non-reporting input as an attribute of a `Reporting::Input::Struct`
    - Trying to use a reporting input as the attribute of a non-reporting `InputObject`
    - Trying to use a non-reporting output as a field of a `Reporting::Output::Struct`
    - Trying to use a reporting output as a field of a `SoberSwag::OutputObject`

This will make migration to the reporting stuff easier so I can hopefully remove the non-reporting stuff (and associated dependency on `Dry::Types`) soon. 