### PR TITLE
Allow `nilable` on Reporting::Input objects as an alternative to `optional`

### DIFF
--- a/lib/sober_swag/reporting/input/interface.rb
+++ b/lib/sober_swag/reporting/input/interface.rb
@@ -27,6 +27,8 @@ module SoberSwag
           self | Null.new
         end
 
+        alias nilable optional
+
         ##
         # A list of this input.
         #


### PR DESCRIPTION
Output objects allow `nilable`, but input do not.

So you end up with a weird incongruity here:

```ruby
# Works
SoberSwag::Reporting::Output.text.nilable
# Does not work
SoberSwag::Reporting::Input.text.nilable
```

With this additional alias, it now works.