### PR TITLE
Add deprecration warnings for non-reporting

### DIFF
--- a/lib/sober_swag.rb
+++ b/lib/sober_swag.rb
@@ -7,6 +7,7 @@ require 'dry-types'
 require 'sober_swag/types'
 require 'sober_swag/version'
 require 'active_support/inflector'
+require 'active_support/deprecation'
 
 ##
 # Root namespace for the SoberSwag Module.
@@ -14,6 +15,8 @@ module SoberSwag
   ##
   # Root Error Class for SoberSwag errors.
   class Error < StandardError; end
+
+  Deprecator = ActiveSupport::Deprecation.new('1.0', 'sober_swag')
 
   autoload :Parser, 'sober_swag/parser'
   autoload :Serializer, 'sober_swag/serializer'
@@ -34,6 +37,8 @@ module SoberSwag
   # @yieldself [SoberSwag::InputObject]
   # @return [Class] the input object class generated
   def self.input_object(parent = nil, &block)
+    SoberSwag::Deprecator.warn('Legacy input objects will be removed in 1.0')
+
     Class.new(parent || SoberSwag::InputObject, &block)
   end
 end

--- a/lib/sober_swag/output_object.rb
+++ b/lib/sober_swag/output_object.rb
@@ -7,6 +7,8 @@ module SoberSwag
   #
   # Under the hood, this is actually all based on {SoberSwag::Serializer::Base}.
   class OutputObject < SoberSwag::Serializer::Base
+    SoberSwag::Deprecator.warn('Do not use OutputObject as it will be removed in 1.0, define a reporting output instead')
+
     autoload(:Field, 'sober_swag/output_object/field')
     autoload(:Definition, 'sober_swag/output_object/definition')
     autoload(:FieldSyntax, 'sober_swag/output_object/field_syntax')
@@ -39,6 +41,8 @@ module SoberSwag
     # @return [Class] the serializer generated.
     # @yieldself [SoberSwag::OutputObject::Definition]
     def self.define(&block)
+      SoberSwag::Deprecator.warn('Legacy OutputObjects will be removed in 1.0')
+
       d = Definition.new.tap do |o|
         o.instance_eval(&block)
       end


### PR DESCRIPTION
Adds deprecation warnings for a few non-reporting classes and modules. These should help us pinpoint down what we still need to migrate over to SoberSwag::Reporting.